### PR TITLE
Frontend_4 Implement Board and Cell components with Neumorphism

### DIFF
--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Cell } from './Cell';
+
+type CellValue = -1 | 0 | 1;
+
+interface BoardProps {
+  board: CellValue[];
+  onCellClick: (index: number) => void;
+  disabled?: boolean;
+}
+
+export const Board: React.FC<BoardProps> = ({ board, onCellClick, disabled }) => {
+  return (
+    <div className="p-4 sm:p-6 rounded-2xl bg-neumorphism-base shadow-neumorphism-flat">
+      <div className="grid grid-cols-8 gap-2 or sm:gap-3 md:gap-4">
+        {board.map((cellValue, index) => (
+          <Cell
+            key={index}
+            value={cellValue}
+            onClick={() => onCellClick(index)}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+type CellValue = -1 | 0 | 1; // -1: Empty, 0: Black, 1: White
+
+interface CellProps {
+  value: CellValue;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+export const Cell: React.FC<CellProps> = ({ value, onClick, disabled }) => {
+  return (
+    <div
+      onClick={!disabled ? onClick : undefined}
+      className={`
+        w-10 h-10 sm:w-12 sm:h-12 md:w-16 md:h-16 lg:w-20 lg:h-20
+        rounded-lg
+        flex items-center justify-center
+        transition-all duration-200 ease-in-out
+        cursor-pointer
+        ${value === -1
+          ? 'bg-neumorphism-base shadow-neumorphism-flat hover:shadow-neumorphism-pressed active:shadow-neumorphism-pressed'
+          : 'bg-neumorphism-base shadow-neumorphism-pressed'
+        }
+      `}
+    >
+      {/* Stone */}
+      {value !== -1 && (
+        <div
+          className={`
+            w-[70%] h-[70%] rounded-full shadow-md transition-all duration-300
+            ${value === 0
+              ? 'bg-gray-800 border-2 border-gray-700'
+              : 'bg-gray-100 border-2 border-white'
+            }
+          `}
+        />
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## 概要
オセロの盤面を表示する中核コンポーネントを実装しました。
Neumorphismデザインシステム（`globals.css`で定義済み）を適用し、立体感のあるUIを実現しています。

## 変更内容
- **`src/components/Cell.tsx`**:
    - オセロの1マスを表現。
    - 状態（空、黒、白）に応じたスタイリング。
    - 空のマスは浮き出し (`shadow-neumorphism-flat`)、石があるマスは凹み (`pressed`) 表現。
    - レスポンシブ対応（画面幅に応じてリサイズ）。
- **`src/components/Board.tsx`**:
    - 64マスのグリッドレイアウト。
    - 盤面全体の背景にもNeumorphismスタイルを適用。

## 動作確認
ローカル環境にて、初期配置および石の設置時のスタイル崩れがないことを確認済み。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce reusable `Board` and `Cell` components rendering an 8x8 Othello grid with responsive neumorphic styling and click handling with optional disable.
> 
> - **Frontend**
>   - **`frontend/src/components/Board.tsx`**
>     - New `Board` component rendering an 8x8 grid of `Cell` from a `board: (-1|0|1)[]`.
>     - Prop-driven click handling via `onCellClick(index)` and optional `disabled`.
>     - Container styled with neumorphic background and responsive grid gaps.
>   - **`frontend/src/components/Cell.tsx`**
>     - New `Cell` component displaying empty (`-1`) or stone (`0` black, `1` white).
>     - Neumorphic flat vs pressed states; responsive sizing; `disabled` gates `onClick`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d3ec6fd3b02cf6658bdd7a6955cc9b29462ad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->