### PR TITLE
style(frontend): update AI level labels to Easy/Normal/Master

### DIFF
--- a/frontend/src/app/newgame/page.tsx
+++ b/frontend/src/app/newgame/page.tsx
@@ -6,11 +6,17 @@ import { useState } from 'react';
 export default function NewGamePage() {
   const router = useRouter();
   const [gameMode, setGameMode] = useState<'ai' | 'human' | null>(null);
+  const [aiLevel, setAiLevel] = useState<string>('v1');
 
   const handleSelectColor = (color: 'black' | 'white') => {
     // Clear any existing game state to start fresh
     localStorage.removeItem('othello_game_state');
-    router.push(`/?player=${color}&mode=${gameMode}`);
+    const query = new URLSearchParams({
+      player: color,
+      mode: gameMode || 'ai',
+      ...(gameMode === 'ai' ? { aiLevel } : {})
+    });
+    router.push(`/?${query.toString()}`);
   };
 
   // First screen: Select game mode
@@ -51,6 +57,35 @@ export default function NewGamePage() {
         <h1 className="text-3xl md:text-4xl font-bold text-neumorphism-text">
           Select Your Color
         </h1>
+
+        {/* AI Level Selector */}
+        <div className="flex flex-col items-center gap-4 w-full max-w-[300px]">
+          <label className="text-lg font-bold text-neumorphism-text">AI Level</label>
+          <div className="flex gap-4 w-full">
+            {[
+              { id: 'v1', label: 'Easy' },
+              { id: 'v2', label: 'Normal' },
+              { id: 'v3', label: 'Master' },
+            ].map((levelObj) => (
+              <button
+                key={levelObj.id}
+                onClick={() => setAiLevel(levelObj.id)}
+                disabled={levelObj.id !== 'v1'}
+                className={`flex-1 py-3 px-4 rounded-xl font-bold transition-all duration-200 ${aiLevel === levelObj.id
+                  ? 'bg-neumorphism-base text-blue-500 shadow-neumorphism-pressed'
+                  : 'bg-neumorphism-base text-neumorphism-text shadow-neumorphism-flat hover:shadow-neumorphism-pressed hover:text-blue-500'
+                  } ${levelObj.id !== 'v1' ? 'opacity-50 cursor-not-allowed shadow-none' : ''}`}
+              >
+                <div className="flex flex-col items-center">
+                  <span>{levelObj.label}</span>
+                  {levelObj.id !== 'v1' && (
+                    <span className="text-[10px] sm:text-xs font-normal opacity-60 mt-1">(Coming Soon)</span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
 
         <div className="flex flex-row gap-8 md:gap-16">
           {/* Black Button */}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -163,25 +163,13 @@ function GameContent() {
             New Game
           </button>
 
-          {/* AI Level Selector */}
+          {/* AI Level Display */}
           {gameMode === 'ai' && (
             <div className="w-full mt-2">
               <label className="block text-sm font-bold text-neumorphism-text mb-2 text-center">AI Level</label>
-              <select
-                value={aiLevelParam}
-                onChange={(e) => {
-                  const newLevel = e.target.value;
-                  const params = new URLSearchParams(searchParams.toString());
-                  params.set('aiLevel', newLevel);
-                  router.replace(`/?${params.toString()}`);
-                }}
-                className="w-full p-2 rounded-xl bg-neumorphism-base text-neumorphism-text shadow-neumorphism-inset font-bold text-center border-none outline-none focus:ring-2 focus:ring-blue-400/50"
-              >
-                <option value="v1">Level 1</option>
-                <option value="v2">Level 2</option>
-                <option value="v3">Level 3</option>
-                {/* Future levels can be added here */}
-              </select>
+              <div className="w-full p-2 rounded-xl bg-neumorphism-base text-neumorphism-text shadow-neumorphism-inset font-bold text-center">
+                {{ 'v1': 'Easy', 'v2': 'Normal', 'v3': 'Master' }[aiLevelParam] || 'Easy'}
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
### フロントエンド
- **UI刷新**: AIレベル選択をゲーム画面から「New Game」画面へ移動しました。
- **レベル表記の変更**: AIレベルの名称を「Easy」「Normal」「Master」に変更しました。
    - **Easy (v1)**: 現在プレイ可能なバージョン。
    - **Normal (v2) / Master (v3)**: 実装予定のため `(Coming Soon)` と表示し、選択不可に設定しています。
- **ゲーム画面**: 選択されたAIレベルを表示専用として表示するように変更しました。
## 検証
- フロントエンドおよびバックエンドの全テストパスを確認済み。
- UI上で意図した通りにレベル選択の有効/無効が切り替わることを確認済み。