### PR TITLE
feat: Cloud Run へのバックエンド移行と自動デプロイ

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+Generate commit messages briefly in Japanese, using Conventional Commits (e.g. `feat:`, `fix:`, `docs:`, `refactor:`).

--- a/.github/workflows/deploy-backend-cloudrun.yml
+++ b/.github/workflows/deploy-backend-cloudrun.yml
@@ -56,5 +56,5 @@ jobs:
             --min-instances=0
             --max-instances=3
             --timeout=60
-          env_vars: RAILS_ENV=production,RAILS_LOG_LEVEL=info
-          secrets: RAILS_MASTER_KEY=RAILS_MASTER_KEY:latest
+          env_vars: RAILS_ENV=production,RAILS_LOG_LEVEL=info,RAILS_LOG_TO_STDOUT=true
+          secrets: SECRET_KEY_BASE=SECRET_KEY_BASE:latest

--- a/.github/workflows/deploy-backend-cloudrun.yml
+++ b/.github/workflows/deploy-backend-cloudrun.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build and push Docker image
         run: |
           IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/${SERVICE}:${GITHUB_SHA}"
-          docker build -t "${IMAGE}" ./backend
+          docker build --platform linux/amd64 -t "${IMAGE}" ./backend
           docker push "${IMAGE}"
           echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/deploy-backend-cloudrun.yml
+++ b/.github/workflows/deploy-backend-cloudrun.yml
@@ -1,0 +1,60 @@
+name: Deploy Backend to Cloud Run
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy-backend-cloudrun.yml'
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: asia-northeast1
+  SERVICE: othello-backend
+  REPOSITORY: othello
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${REGION}-docker.pkg.dev --quiet
+
+      - name: Build and push Docker image
+        run: |
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/${SERVICE}:${GITHUB_SHA}"
+          docker build -t "${IMAGE}" ./backend
+          docker push "${IMAGE}"
+          echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE }}
+          region: ${{ env.REGION }}
+          image: ${{ env.IMAGE }}
+          flags: >-
+            --allow-unauthenticated
+            --port=8080
+            --memory=512Mi
+            --cpu=1
+            --min-instances=0
+            --max-instances=3
+            --timeout=60
+          env_vars: RAILS_ENV=production,RAILS_LOG_LEVEL=info
+          secrets: RAILS_MASTER_KEY=RAILS_MASTER_KEY:latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -45,5 +45,6 @@ COPY bin/docker-entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 3001
+# Cloud Run injects PORT (default 8080); Puma reads it via config/puma.rb
+EXPOSE 8080
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/backend/bin/docker-entrypoint.sh
+++ b/backend/bin/docker-entrypoint.sh
@@ -4,36 +4,23 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /app/backend/tmp/pids/server.pid
 
-# Compile Othello AI binary
-echo "Compiling Othello AI (v1)..."
 cd /app/backend
-if [ -f "othelloai_logic/v1/othello.cpp" ]; then
-    g++ -O3 -o othelloai_logic/v1/othello othelloai_logic/v1/othello.cpp
-    chmod +x othelloai_logic/v1/othello
-    echo "Compilation successful (v1)."
+
+if [ "$RAILS_ENV" = "production" ]; then
+  echo "Preparing production database..."
+  bundle exec rails db:prepare
 else
-    echo "Warning: othelloai_logic/v1/othello.cpp not found."
+  # Compile Othello AI binaries at dev startup (production uses pre-built binaries from the builder stage)
+  for version in v1 v2 v3; do
+    echo "Compiling Othello AI (${version})..."
+    if [ -f "othelloai_logic/${version}/othello.cpp" ]; then
+      g++ -O3 -o "othelloai_logic/${version}/othello" "othelloai_logic/${version}/othello.cpp"
+      chmod +x "othelloai_logic/${version}/othello"
+      echo "Compilation successful (${version})."
+    else
+      echo "Warning: othelloai_logic/${version}/othello.cpp not found."
+    fi
+  done
 fi
 
-# Compile Othello AI binary (v2)
-echo "Compiling Othello AI (v2)..."
-if [ -f "othelloai_logic/v2/othello.cpp" ]; then
-    g++ -O3 -o othelloai_logic/v2/othello othelloai_logic/v2/othello.cpp
-    chmod +x othelloai_logic/v2/othello
-    echo "Compilation successful (v2)."
-else
-    echo "Warning: othelloai_logic/v2/othello.cpp not found."
-fi
-
-# Compile Othello AI binary (v3)
-echo "Compiling Othello AI (v3)..."
-if [ -f "othelloai_logic/v3/othello.cpp" ]; then
-    g++ -O3 -o othelloai_logic/v3/othello othelloai_logic/v3/othello.cpp
-    chmod +x othelloai_logic/v3/othello
-    echo "Compilation successful (v3)."
-else
-    echo "Warning: othelloai_logic/v3/othello.cpp not found."
-fi
-
-# Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -21,14 +21,14 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  # Cloud Run terminates TLS at the load balancer.
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]

--- a/docs/DEPLOY_CLOUD_RUN.md
+++ b/docs/DEPLOY_CLOUD_RUN.md
@@ -32,16 +32,18 @@ gcloud artifacts repositories create othello \
   --description="Othello backend images"
 ```
 
-### RAILS_MASTER_KEY を Secret Manager に登録
+### SECRET_KEY_BASE を Secret Manager に登録
+
+Railway など既存環境の `SECRET_KEY_BASE` を流用します（`master.key` は不要）。
 
 ```bash
-# backend/config/master.key の内容を Secret に保存
-gcloud secrets create RAILS_MASTER_KEY \
+# 値は画面に残さないよう、変数経由で渡すのが安全
+echo -n "$SECRET_KEY_BASE" | gcloud secrets create SECRET_KEY_BASE \
+  --data-file=- \
   --replication-policy="automatic"
-
-gcloud secrets versions add RAILS_MASTER_KEY \
-  --data-file=backend/config/master.key
 ```
+
+すでに Secret がある場合は `gcloud secrets versions add SECRET_KEY_BASE --data-file=-` で更新します。
 
 ## 2. 手動デプロイ（初回確認用）
 
@@ -64,8 +66,8 @@ gcloud run deploy "${SERVICE}" \
   --allow-unauthenticated \
   --port=8080 \
   --memory=512Mi \
-  --set-env-vars="RAILS_ENV=production,RAILS_LOG_LEVEL=info" \
-  --set-secrets="RAILS_MASTER_KEY=RAILS_MASTER_KEY:latest"
+  --set-env-vars="RAILS_ENV=production,RAILS_LOG_LEVEL=info,RAILS_LOG_TO_STDOUT=true" \
+  --set-secrets="SECRET_KEY_BASE=SECRET_KEY_BASE:latest"
 ```
 
 デプロイ後、表示される URL（例: `https://othello-backend-xxxxx-an.a.run.app`）を控えてください。

--- a/docs/DEPLOY_CLOUD_RUN.md
+++ b/docs/DEPLOY_CLOUD_RUN.md
@@ -1,0 +1,140 @@
+# Cloud Run へのバックエンドデプロイ手順
+
+Railway から Google Cloud Run へバックエンド API を移行するための手順です。
+
+## 前提
+
+- Google Cloud プロジェクトが作成済みであること
+- 課金（Billing）が有効であること
+- フロントエンド（例: Vercel）側で `NEXT_PUBLIC_API_URL` を Cloud Run の URL に更新できること
+
+## 1. GCP の初期設定
+
+### API の有効化
+
+```bash
+gcloud services enable \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com \
+  cloudbuild.googleapis.com
+```
+
+### Artifact Registry リポジトリの作成
+
+```bash
+export PROJECT_ID="your-gcp-project-id"
+export REGION="asia-northeast1"
+
+gcloud artifacts repositories create othello \
+  --repository-format=docker \
+  --location="${REGION}" \
+  --description="Othello backend images"
+```
+
+### RAILS_MASTER_KEY を Secret Manager に登録
+
+```bash
+# backend/config/master.key の内容を Secret に保存
+gcloud secrets create RAILS_MASTER_KEY \
+  --replication-policy="automatic"
+
+gcloud secrets versions add RAILS_MASTER_KEY \
+  --data-file=backend/config/master.key
+```
+
+## 2. 手動デプロイ（初回確認用）
+
+```bash
+export PROJECT_ID="your-gcp-project-id"
+export REGION="asia-northeast1"
+export SERVICE="othello-backend"
+export IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/othello/${SERVICE}:latest"
+
+# ビルド & プッシュ
+gcloud auth configure-docker ${REGION}-docker.pkg.dev
+docker build -t "${IMAGE}" ./backend
+docker push "${IMAGE}"
+
+# Cloud Run にデプロイ
+gcloud run deploy "${SERVICE}" \
+  --image="${IMAGE}" \
+  --region="${REGION}" \
+  --platform=managed \
+  --allow-unauthenticated \
+  --port=8080 \
+  --memory=512Mi \
+  --set-env-vars="RAILS_ENV=production,RAILS_LOG_LEVEL=info" \
+  --set-secrets="RAILS_MASTER_KEY=RAILS_MASTER_KEY:latest"
+```
+
+デプロイ後、表示される URL（例: `https://othello-backend-xxxxx-an.a.run.app`）を控えてください。
+
+### 動作確認
+
+```bash
+export BACKEND_URL="https://othello-backend-xxxxx-an.a.run.app"
+
+# ヘルスチェック
+curl "${BACKEND_URL}/up"
+
+# AI API の確認
+curl -X POST "${BACKEND_URL}/api/v1/games/next_move" \
+  -H "Content-Type: application/json" \
+  -d '{"board":"0000000000000000000000000001200000021000000000000000000000000000","turn":0,"aiLevel":"v1"}'
+```
+
+## 3. GitHub Actions による自動デプロイ
+
+`.github/workflows/deploy-backend-cloudrun.yml` が `main` ブランチへの `backend/**` 変更時にデプロイします。
+
+### 必要な GitHub Secrets
+
+| Secret | 説明 |
+|--------|------|
+| `GCP_PROJECT_ID` | GCP プロジェクト ID |
+| `GCP_SA_KEY` | デプロイ用サービスアカウントの JSON キー |
+
+### サービスアカウントの作成例
+
+```bash
+export PROJECT_ID="your-gcp-project-id"
+export SA_NAME="github-cloudrun-deploy"
+
+gcloud iam service-accounts create "${SA_NAME}" \
+  --display-name="GitHub Actions Cloud Run Deploy"
+
+export SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+for ROLE in \
+  roles/run.admin \
+  roles/artifactregistry.writer \
+  roles/iam.serviceAccountUser \
+  roles/secretmanager.secretAccessor; do
+  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="${ROLE}"
+done
+
+gcloud iam service-accounts keys create sa-key.json \
+  --iam-account="${SA_EMAIL}"
+```
+
+`sa-key.json` の内容を GitHub Secret `GCP_SA_KEY` に登録してください。
+
+## 4. フロントエンドの更新
+
+Cloud Run の URL が確定したら、フロントエンドの環境変数を更新します。
+
+```
+NEXT_PUBLIC_API_URL=https://othello-backend-xxxxx-an.a.run.app/api/v1
+```
+
+Vercel などホスティング側で設定後、フロントエンドを再デプロイしてください。
+
+## 補足
+
+- Cloud Run は `PORT` 環境変数（デフォルト 8080）で待ち受けます。Puma は `config/puma.rb` でこれを参照します。
+- C++ AI バイナリは Docker ビルド時にコンパイル済みです。本番起動時の再コンパイルは行いません。
+- SQLite はコンテナ内の ephemeral storage に保存されます。本 API は DB を使わないため、再起動後も API 自体は動作します。
+- `/up` エンドポイントが Cloud Run のヘルスチェックに使われます。

--- a/docs/DEPLOY_CLOUD_RUN.md
+++ b/docs/DEPLOY_CLOUD_RUN.md
@@ -53,9 +53,9 @@ export REGION="asia-northeast1"
 export SERVICE="othello-backend"
 export IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/othello/${SERVICE}:latest"
 
-# ビルド & プッシュ
+# ビルド & プッシュ（Cloud Run は linux/amd64。Apple Silicon では --platform 必須）
 gcloud auth configure-docker ${REGION}-docker.pkg.dev
-docker build -t "${IMAGE}" ./backend
+docker build --platform linux/amd64 -t "${IMAGE}" ./backend
 docker push "${IMAGE}"
 
 # Cloud Run にデプロイ


### PR DESCRIPTION
## 概要
バックエンドを Railway から Google Cloud Run へ移行し、GitHub Actions による自動デプロイを追加します。

## 主な変更点
- Cloud Run 向け Dockerfile / entrypoint / production SSL 設定
- `SECRET_KEY_BASE` を使うデプロイ workflow（`linux/amd64` ビルド）
- Cloud Run デプロイ手順ドキュメント（`docs/DEPLOY_CLOUD_RUN.md`）
- `.cursorrules` 追加

## テスト計画
- [x] 手動で Cloud Run にデプロイ済み
- [x] `/up` と `/api/v1/games/next_move` の動作確認済み
- [ ] GitHub Actions の自動デプロイ設定後に workflow 実行確認


Made with [Cursor](https://cursor.com)