### PR TITLE
ci: Cloud Run デプロイを WIF 認証に切替

### DIFF
--- a/.github/workflows/deploy-backend-cloudrun.yml
+++ b/.github/workflows/deploy-backend-cloudrun.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/docs/DEPLOY_CLOUD_RUN.md
+++ b/docs/DEPLOY_CLOUD_RUN.md
@@ -89,24 +89,30 @@ curl -X POST "${BACKEND_URL}/api/v1/games/next_move" \
 ## 3. GitHub Actions による自動デプロイ
 
 `.github/workflows/deploy-backend-cloudrun.yml` が `main` ブランチへの `backend/**` 変更時にデプロイします。
+組織ポリシーでサービスアカウントキー作成が禁止されているため、**Workload Identity Federation（鍵なし）** を使います。
 
 ### 必要な GitHub Secrets
 
 | Secret | 説明 |
 |--------|------|
-| `GCP_PROJECT_ID` | GCP プロジェクト ID |
-| `GCP_SA_KEY` | デプロイ用サービスアカウントの JSON キー |
+| `GCP_PROJECT_ID` | GCP プロジェクト ID（例: `othello-gui`） |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | WIF プロバイダのフルパス |
+| `GCP_SERVICE_ACCOUNT` | デプロイ用 SA のメール |
 
-### サービスアカウントの作成例
+### セットアップ例（othello-gui）
 
 ```bash
-export PROJECT_ID="your-gcp-project-id"
-export SA_NAME="github-cloudrun-deploy"
+export PROJECT_ID="othello-gui"
+export PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+export SA_EMAIL="github-cloudrun-deploy@${PROJECT_ID}.iam.gserviceaccount.com"
+export POOL_ID="github-actions"
+export PROVIDER_ID="github-oidc"
+export REPO="nana743533/Othello_GUI"
 
-gcloud iam service-accounts create "${SA_NAME}" \
+gcloud services enable iamcredentials.googleapis.com
+
+gcloud iam service-accounts create github-cloudrun-deploy \
   --display-name="GitHub Actions Cloud Run Deploy"
-
-export SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 
 for ROLE in \
   roles/run.admin \
@@ -118,11 +124,32 @@ for ROLE in \
     --role="${ROLE}"
 done
 
-gcloud iam service-accounts keys create sa-key.json \
-  --iam-account="${SA_EMAIL}"
+gcloud iam workload-identity-pools create "${POOL_ID}" \
+  --location="global" \
+  --display-name="GitHub Actions"
+
+gcloud iam workload-identity-pools providers create-oidc "${PROVIDER_ID}" \
+  --location="global" \
+  --workload-identity-pool="${POOL_ID}" \
+  --display-name="GitHub OIDC" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner == 'nana743533'"
+
+gcloud iam service-accounts add-iam-policy-binding "${SA_EMAIL}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${REPO}"
 ```
 
-`sa-key.json` の内容を GitHub Secret `GCP_SA_KEY` に登録してください。
+GitHub Secrets の例:
+
+```text
+GCP_PROJECT_ID=othello-gui
+GCP_SERVICE_ACCOUNT=github-cloudrun-deploy@othello-gui.iam.gserviceaccount.com
+GCP_WORKLOAD_IDENTITY_PROVIDER=projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-actions/providers/github-oidc
+```
+
+手動実行は Actions → Deploy Backend to Cloud Run → Run workflow から可能です。
 
 ## 4. フロントエンドの更新
 


### PR DESCRIPTION
## 概要
組織ポリシーで SA キー作成が禁止されているため、GitHub Actions の認証を Workload Identity Federation に切り替えます。

## 主な変更点
- `credentials_json` から WIF（`GCP_WORKLOAD_IDENTITY_PROVIDER` / `GCP_SERVICE_ACCOUNT`）へ変更
- デプロイ手順ドキュメントを WIF 前提に更新

## テスト計画
- [ ] Actions で Deploy Backend to Cloud Run を手動実行
- [ ] Cloud Run へのデプロイ成功を確認


Made with [Cursor](https://cursor.com)