### PR TITLE
ci: Artifact Registry push 認証を修正

### DIFF
--- a/.github/workflows/deploy-backend-cloudrun.yml
+++ b/.github/workflows/deploy-backend-cloudrun.yml
@@ -24,17 +24,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
+      - id: auth
+        name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${REGION}-docker.pkg.dev --quiet
+      - name: Log in to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Build and push Docker image
         run: |


### PR DESCRIPTION
## 概要
WIF 認証後の Docker push が失敗していたため、`docker/login-action` + access_token 方式に変更します。

## 主な変更点
- `gcloud auth configure-docker` をやめて `docker/login-action@v3` を使用
- `token_format: access_token` を有効化

## テスト計画
- [ ] Deploy Backend to Cloud Run workflow が成功すること


Made with [Cursor](https://cursor.com)